### PR TITLE
Create chart header and use fullscreen api as example

### DIFF
--- a/src/components/ChartHelpers/chartHeader.js
+++ b/src/components/ChartHelpers/chartHeader.js
@@ -1,0 +1,54 @@
+import React from 'react';
+import { Label } from "reactstrap"
+import PropTypes from 'prop-types';
+
+/**
+ * The header for a chart.
+ * This component renders the title and an optional button if a callback option if passed in.
+ * 
+ * @example
+ * return <ChartHeader title="My Line Chart" />
+ * 
+ * @example
+ * return (
+ *  <ChartHeader
+ *    title="My Line Chart with Action"
+ *    callbackOpts={{
+ *      action: () => alert('called action'),
+ *      icon: 'dropicons-warning',
+ *    }}
+ *  />
+ * )
+ */
+const ChartHeader = (props) => {
+  const { title, callbackOpts } = props
+  let action, icon
+  if (callbackOpts) {
+    action = callbackOpts.action
+    icon = callbackOpts.icon
+    if (!action || typeof action !== 'function') {
+      console.warn('Supplied callback opts without a valid action. A button will not be rendered.')
+    }
+    if (!icon || typeof icon !== 'string') {
+      console.warn('Supplied callback opts without a valid icon. A button will not be rendered.')
+    }
+  }
+  return (
+    <div style={{ width: '100%', display: 'flex', justifyContent: 'space-between'}}>
+      <Label className="control-label">{title}</Label>
+      {action ? (
+        <button onClick={action}><i className={icon} /></button>
+      ) : null}
+    </div>
+  )
+}
+
+ChartHeader.propTypes = {
+  title: PropTypes.string.isRequired,
+  callbackOpts: PropTypes.shape({
+    action: PropTypes.func,
+    icon: PropTypes.string,
+  }),
+}
+
+export default ChartHeader

--- a/src/pages/Dashboard-blog/apr-tracker-short.js
+++ b/src/pages/Dashboard-blog/apr-tracker-short.js
@@ -272,27 +272,26 @@ class AprTrackerShort extends React.Component {
             </CardBody>
           </Card>
           <Card>
-            <CardBody>
-              <div className="ag-theme-alpine" style={{height: 400}}>
-                <Label className="control-label">Hover Mouse for Column Descriptions</Label>
-                <AgGridReact
-                  onGridReady={this.onGridReady.bind(this)}
-                  rowData={this.state.rowData}
-                >
-                  <AgGridColumn field="symbol" sortable={true} filter={true} resizable={true} headerTooltip='Symbol'></AgGridColumn>
-                  <AgGridColumn field="AlphaDefi APR Score" sortable={true} filter={true} valueFormatter={scoreFormatter} resizable={true}  headerTooltip='Current Yield / rolling 21 day vol'></AgGridColumn>
-                  <AgGridColumn field="current" sortable={true} filter={true} valueFormatter={pctFormatter} resizable={true}  headerTooltip='most recently calculated APY'></AgGridColumn>
-                  <AgGridColumn field="mean" sortable={true} filter={true} valueFormatter={pctFormatter} resizable={true}  headerTooltip='mean historical apr, normally the apr this pool trades at'></AgGridColumn>
-                  <AgGridColumn field="Three SD" sortable={true} filter={true} valueFormatter={pctFormatter} resizable={true}  headerTooltip='+ three standard deviations from mean'></AgGridColumn>
-                  <AgGridColumn field="Neg Three SD" sortable={true} filter={true} valueFormatter={pctFormatter} resizable={true}  headerTooltip='- three standard deviations from mean'></AgGridColumn>
-                  <AgGridColumn field="max" sortable={true} filter={true} valueFormatter={pctFormatter} resizable={true}  headerTooltip='max apr last 21 days'></AgGridColumn>
-                  <AgGridColumn field="min" sortable={true} filter={true} valueFormatter={pctFormatter} resizable={true}   headerTooltip='min apr last 21 days'></AgGridColumn>
-                  <AgGridColumn field="std" sortable={true} filter={true} valueFormatter={pctFormatter} resizable={true}  headerTooltip='std of historical apr'></AgGridColumn>
-                  <AgGridColumn field="Historical 5th % Spread" sortable={true} filter={true} valueFormatter={pctFormatter} resizable={true}  headerTooltip='Historical 5th % APR'></AgGridColumn>
-                  <AgGridColumn field="Historical 95th % Spread" sortable={true} filter={true} valueFormatter={pctFormatter} resizable={true}  headerTooltip='Historical 95th % APR'></AgGridColumn>
-                </AgGridReact>
-              </div>
-            </CardBody>
+          <CardBody>
+            <div className="ag-theme-alpine" style={{height: 400}}>
+            <Label className="control-label">Hover Mouse for Column Descriptions</Label>
+            <AgGridReact
+               onGridReady={this.onGridReady.bind(this)}
+               rowData={this.state.rowData}>
+                <AgGridColumn field="symbol" sortable={true} filter={true} resizable={true} headerTooltip='Symbol'></AgGridColumn>
+                <AgGridColumn field="AlphaDefi APR Score" sortable={true} filter={true} valueFormatter={scoreFormatter} resizable={true}  headerTooltip='Current Yield / rolling 21 day vol'></AgGridColumn>
+                <AgGridColumn field="current" sortable={true} filter={true} valueFormatter={pctFormatter} resizable={true}  headerTooltip='most recently calculated APY'></AgGridColumn>
+                <AgGridColumn field="mean" sortable={true} filter={true} valueFormatter={pctFormatter} resizable={true}  headerTooltip='mean historical apr, normally the apr this pool trades at'></AgGridColumn>
+                <AgGridColumn field="Three SD" sortable={true} filter={true} valueFormatter={pctFormatter} resizable={true}  headerTooltip='+ three standard deviations from mean'></AgGridColumn>
+                <AgGridColumn field="Neg Three SD" sortable={true} filter={true} valueFormatter={pctFormatter} resizable={true}  headerTooltip='- three standard deviations from mean'></AgGridColumn>
+                <AgGridColumn field="max" sortable={true} filter={true} valueFormatter={pctFormatter} resizable={true}  headerTooltip='max apr last 21 days'></AgGridColumn>
+                <AgGridColumn field="min" sortable={true} filter={true} valueFormatter={pctFormatter} resizable={true}   headerTooltip='min apr last 21 days'></AgGridColumn>
+                <AgGridColumn field="std" sortable={true} filter={true} valueFormatter={pctFormatter} resizable={true}  headerTooltip='std of historical apr'></AgGridColumn>
+                <AgGridColumn field="Historical 5th % Spread" sortable={true} filter={true} valueFormatter={pctFormatter} resizable={true}  headerTooltip='Historical 5th % APR'></AgGridColumn>
+                <AgGridColumn field="Historical 95th % Spread" sortable={true} filter={true} valueFormatter={pctFormatter} resizable={true}  headerTooltip='Historical 95th % APR'></AgGridColumn>
+            </AgGridReact>
+            </div>
+          </CardBody>
           </Card>
         </Col>
       </React.Fragment>


### PR DESCRIPTION
Browsers have a Fullscreen Api that might help with chart and table legibility on mobile devices. This is an example usage.

One problem with this approach is that iOS does not support this Api. There is also some more work to do to make this reliable on Android. This is just a proof of concept.